### PR TITLE
ITEA 07 - Green Grade (OCP)

### DIFF
--- a/kata-instructions.md
+++ b/kata-instructions.md
@@ -1,4 +1,4 @@
-# ITEA 06 - Yellow Grade: Liskov Substitution Principle (LSP)
+# ITEA 07 - Green Grade: Open-Closed Principle (OCP)
 
 ### Introduction
 
@@ -11,48 +11,23 @@ them in their digital transformation.
 * Try to apply TDD (test-driven development) as diligently as possible. But *pragmatism > dogma* -- cover business rules, not code lines.
 * Have fun and ask lots of questions!
 
-## Task 1 - Shopping Cart and Discounts
+## Task 1 - Analysis and Discussion
 
-Our colleagues have recently started designing the domain model for the shopping  cart (see
-`ShoppingCartTest` and work your way from there). In particular, we can add products to the
-shopping cart, and since recently also vouchers, which are implemented as a kind of product.
-Vouchers could be given to customers for example via advertisements, referrals, and other
-marketing campaigns. Vouchers cannot be bought by customers, only redeemed to get a discount.
+While we don't want to predict which future changes *might* happen and prepare for every possibility in advance – most
+of them will never happen after all – we can still sometimes be pretty sure about *certain kinds of changes*.
+We call these *expected variation*, and we want to make these changes as simple  and efficient as possible, with little
+risk of breaking existing code and without having to make changes in many parts of the code base.
 
-### a) Let's have a closer look at this design. Vouchers are implemented as products, because that is what we can add to the shopping cart. Any problems with this?
+Let's open the enum type `ProductName`. Looking at where and how this enum type is used:
 
-Tip: Consider drawing a diagram if it helps with understanding and discussing the situation.
+- Which kind of *expected variation* will cause changes to propagate through the code base?
+- Where are different classes (possibly including tests) coupled together via this enum type?
+- Which kind of change that should not affect the tests would break certain unit tests?<br>
+  (Note: Regularly breaking unit tests via changes that should not affect them is a typical symptom of an OCP violation.)
 
-<details>
-<summary>Hint 1</summary>
-Vouchers are not actually products that the customers can order, even though they might add them
-to the shopping cart, so the code does not really match the domain. But that is only the
-second-biggest problem. What do we do with the products once they are added to the shopping cart,
-and what do we do with the vouchers?
-</details>
+## Task 2 - Refactoring
 
-<details>
-<summary>Hint 2</summary>
-The problem is that vouchers are not used like products. They only extend `Product` so that
-they can be added to the shopping cart, but the shopping cart has to check at runtime whether
-it is a voucher, because vouchers have neither a product ID nor a price. Instead, they have
-a discount amount or percentage, which the products do not have.
-</details>
-
-### b) How can we fix this problem? Once we found a better design, let's start refactoring.
-
-**Note:** Remember to change the tests first, if necessary, and run them often. Where possible, try to
-keep existing functionality intact while gradually refactoring to the improved design, instead of
-"replacing", i.e., rewriting the whole design at once.
-
-<details>
-<summary>Hint</summary>
-Here is one suggested solution:<br/>
-Instead of treating vouchers as products just so we can add them to the shopping cart, we
-can simply allow adding vouchers in addition to products (e.g., `addProduct(productId)` and
-`addVoucher(voucher)`). That way we can still have the shopping cart determine the total price
-for us with a simple API that encapsulates most of the details, but we can avoid this type
-hierarchy where the caller needs to know about the specific subtypes.
-</details>
-
-### c) How easy was it to change the tests compared to changing the implementation? Why?
+After thinking about the changes that will definitely be happening regularly during the application's lifetime,
+can we find a way to limit these expected changes to certain parts of the code base? We call this a *strategic closure*,
+which acts like a "barrier" for how far changes can propagate. Who likes to make changes throughout many files,
+possibly breaking stuff unknowingly, each time we make a small change?

--- a/kata-instructions.md
+++ b/kata-instructions.md
@@ -25,9 +25,50 @@ Let's open the enum type `ProductName`. Looking at where and how this enum type 
 - Which kind of change that should not affect the tests would break certain unit tests?<br>
   (Note: Regularly breaking unit tests via changes that should not affect them is a typical symptom of an OCP violation.)
 
-## Task 2 - Refactoring
+<details>
+<summary>Hint</summary>
+- To add a new product (almost certainly going to happen) we want to ideally only do that, add the product,
+  without also having to change other existing files and potentially breaking existing behavior. Also, the product
+  name should just be data.<br>
+- To change (e.g., rename) an existing product, we want to just change the respective product data, and not also
+  fix tests that should not be coupled to concrete product data.
+</details>
+
+## Task 2 - Experiencing the Pain
+
+### a) Add a new product, wardrobe "Ingeborg" for 249,99&nbsp;€.
+
+- How easy was that?
+- How obvious was it what needs to change?
+- How far did the changes propagate?
+- Did you break anything in the process?
+
+### b) Rename chair "Elsa" to "Olaf".
+
+- How easy was that?
+- How obvious was it what needs to change?
+- How far did the changes propagate?
+- Did you break anything in the process?
+
+## Task 3 - Refactoring
 
 After thinking about the changes that will definitely be happening regularly during the application's lifetime,
 can we find a way to limit these expected changes to certain parts of the code base? We call this a *strategic closure*,
 which acts like a "barrier" for how far changes can propagate. Who likes to make changes throughout many files,
 possibly breaking stuff unknowingly, each time we make a small change?
+
+## Task 4 - Expected Variation
+
+### a) Add a new product, closet "Ragnarök" for 329,99&nbsp;€.
+
+- How easy was that?
+- How obvious was it what needs to change?
+- How far did the changes propagate?
+- Did you break anything in the process?
+
+### b) Rename picture "Norway" to "Oslo".
+
+- How easy was that?
+- How obvious was it what needs to change?
+- How far did the changes propagate?
+- Did you break anything in the process?

--- a/src/main/java/com/ite/itea/ecommerce/domain/retail/GardenBench.java
+++ b/src/main/java/com/ite/itea/ecommerce/domain/retail/GardenBench.java
@@ -14,15 +14,15 @@ public class GardenBench extends Product {
     private final int amountDefaultElements;
     private final int amountPlantElements;
     private final boolean hasBackrest;
-    private final boolean isDelivery;
+    private final boolean shouldBeDelivered;
 
-    public GardenBench(ProductId id, int lengthInCentimeters, int amountDefaultElements, int amountPlantElements, boolean hasBackrest, boolean isDelivery) {
+    public GardenBench(ProductId id, int lengthInCentimeters, int amountDefaultElements, int amountPlantElements, boolean hasBackrest, boolean shouldBeDelivered) {
         super(id, "Garden bench");
         this.lengthInCentimeters = lengthInCentimeters;
         this.amountDefaultElements = amountDefaultElements;
         this.amountPlantElements = amountPlantElements;
         this.hasBackrest = hasBackrest;
-        this.isDelivery = isDelivery;
+        this.shouldBeDelivered = shouldBeDelivered;
     }
 
     @Override
@@ -40,7 +40,7 @@ public class GardenBench extends Product {
         return "Order for a garden bench:\n"
                 + formatElementsText(amountPlantElements, hasBackrest)
                 + "Total length: " + totalLength(amountPlantElements, lengthInCentimeters) + " cm\n"
-                + formatDeliveryText(isDelivery, deliveryPrice)
+                + formatDeliveryText(shouldBeDelivered, deliveryPrice)
                 + formatDeliveryPriceText(productPrice, totalPriceIncludingDelivery);
     }
 
@@ -53,7 +53,7 @@ public class GardenBench extends Product {
     }
 
     private EuroPrice calculateDeliveryPrice() {
-        if (!isDelivery) {
+        if (!shouldBeDelivered) {
             return EuroPrice.zero();
         }
 
@@ -101,7 +101,7 @@ public class GardenBench extends Product {
     }
 
     private String formatDeliveryPriceText(EuroPrice priceWithoutDelivery, EuroPrice priceIncludingDelivery) {
-        if (isDelivery) {
+        if (shouldBeDelivered) {
             return "Total price (without delivery): " + priceWithoutDelivery.formatPrice() + "\n"
                     + "Total price (including delivery): " + priceIncludingDelivery.formatPrice() + "\n";
         } else {

--- a/src/test/java/com/ite/itea/ecommerce/adapters/out/ReceiptPresenterTest.java
+++ b/src/test/java/com/ite/itea/ecommerce/adapters/out/ReceiptPresenterTest.java
@@ -2,12 +2,13 @@ package com.ite.itea.ecommerce.adapters.out;
 
 import com.ite.itea.ecommerce.adapters.out.presenter.ReceiptPresenter;
 import com.ite.itea.ecommerce.domain.retail.*;
-import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ReceiptPresenterTest {
 
@@ -58,7 +59,7 @@ class ReceiptPresenterTest {
     void shouldReturnCorrectReceipts(Order order, EuroPrice expectedTotalPrice, String expectedReceiptText) {
         var receipt = receiptPresenter.prepareReceipt(order);
 
-        BDDAssertions.then(receipt.priceInCents()).isEqualTo(expectedTotalPrice.asCents());
-        BDDAssertions.then(receipt.text()).isEqualTo(expectedReceiptText);
+        assertThat(receipt.priceInCents()).isEqualTo(expectedTotalPrice.asCents());
+        assertThat(receipt.text()).isEqualTo(expectedReceiptText);
     }
 }

--- a/src/test/java/com/ite/itea/ecommerce/integration/in/controller/CheckoutControllerTest.java
+++ b/src/test/java/com/ite/itea/ecommerce/integration/in/controller/CheckoutControllerTest.java
@@ -33,8 +33,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAPictureNorwayToTheController() {
-        var orderPictureNorway = createItem(ProductName.PICTURE_NORWAY, 2,999);
-        var orderRequest = createOrder(orderPictureNorway);
+        var orderPictureNorway = new ItemRequest(ProductName.PICTURE_NORWAY, 2, 999);
+        var orderRequest = new OrderRequest(List.of(orderPictureNorway));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -45,8 +45,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAPictureSwedenToTheController() {
-        var orderPictureSweden = createItem(ProductName.PICTURE_SWEDEN, 2, 1299);
-        var orderRequest = createOrder(orderPictureSweden);
+        var orderPictureSweden = new ItemRequest(ProductName.PICTURE_SWEDEN, 2, 1299);
+        var orderRequest = new OrderRequest(List.of(orderPictureSweden));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -57,8 +57,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAPictureFinlandToTheController() {
-        var orderPictureFinland = createItem(ProductName.PICTURE_FINLAND, 2, 1499);
-        var orderRequest = createOrder(orderPictureFinland);
+        var orderPictureFinland = new ItemRequest(ProductName.PICTURE_FINLAND, 2, 1499);
+        var orderRequest = new OrderRequest(List.of(orderPictureFinland));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -69,8 +69,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAChairElsaToTheController() {
-        var orderChairElsa = createItem(ProductName.CHAIR_ELSA, 2, 3000);
-        var orderRequest = createOrder(orderChairElsa);
+        var orderChairElsa = new ItemRequest(ProductName.CHAIR_ELSA, 2, 3000);
+        var orderRequest = new OrderRequest(List.of(orderChairElsa));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -81,8 +81,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAChairKnutToTheController() {
-        var orderChairKnut = createItem(ProductName.CHAIR_KNUT, 2, 4100);
-        var orderRequest = createOrder(orderChairKnut);
+        var orderChairKnut = new ItemRequest(ProductName.CHAIR_KNUT, 2, 4100);
+        var orderRequest = new OrderRequest(List.of(orderChairKnut));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -93,8 +93,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithAChairLarsToTheController() {
-        var orderChairLars = createItem(ProductName.CHAIR_LARS, 2, 5800);
-        var orderRequest = createOrder(orderChairLars);
+        var orderChairLars = new ItemRequest(ProductName.CHAIR_LARS, 2, 5800);
+        var orderRequest = new OrderRequest(List.of(orderChairLars));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -105,8 +105,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithATableLottaToTheController() {
-        var orderTableLotta = createItem(ProductName.TABLE_LOTTA, 2, 500);
-        var orderRequest = createOrder(orderTableLotta);
+        var orderTableLotta = new ItemRequest(ProductName.TABLE_LOTTA, 2, 500);
+        var orderRequest = new OrderRequest(List.of(orderTableLotta));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -117,8 +117,8 @@ class CheckoutControllerTest {
 
     @Test
     void shouldReturnCorrectReceiptWhenSendingRequestWithATableLolaToTheController() {
-        var orderTableLola = createItem(ProductName.TABLE_LOLA, 2, 1300);
-        var orderRequest = createOrder(orderTableLola);
+        var orderTableLola = new ItemRequest(ProductName.TABLE_LOLA, 2, 1300);
+        var orderRequest = new OrderRequest(List.of(orderTableLola));
 
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
@@ -132,13 +132,5 @@ class CheckoutControllerTest {
         var entity = this.testRestTemplate.getForEntity("http://localhost:" + this.actuatorPort + "/actuator", Map.class);
 
         then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-    }
-
-    private OrderRequest createOrder(ItemRequest item) {
-        return new OrderRequest(List.of(item));
-    }
-
-    private ItemRequest createItem(ProductName name, int amount, long price) {
-        return new ItemRequest(name, amount, price);
     }
 }


### PR DESCRIPTION
Mit diesem Kata werden bestehende technische Schulden (der Enum-Typ `ProductName`) abgebaut:
- Um ein neues Produkt hinzuzufügen wollen wir idealerweise nur genau das tun, das Produkt hinzufügen, ohne bestehende Enums und möglicherweise damit zusammenhängende Switch-Statements u.ä. dafür anpassen zu müssen.
- Um bestehende Produkte umzubenennen wollen wir nur die Daten des Produktes ändern, nicht auch bestehende Tests anpassen müssen, die nicht an konkrete Produktdaten gecoupled sein sollten.